### PR TITLE
FIX: Change number of parcel in two ways request

### DIFF
--- a/src/shipment.php
+++ b/src/shipment.php
@@ -205,6 +205,7 @@ class shipment extends wsdata {
 			$this->skybillValue[] = $parcel[3];
 		}
 		
+		$this->setnumberOfParcel(count($this->skybillValue));
 	}
 	/********
 	* Makes one parcel 2 ways


### PR DESCRIPTION
Le nombre de parcel n'était pas mis a jours après l'assignation de skybillValue dans la cas de la transformation de la requête en 'twoWays'. J'avais oublié de faire cette PR, car j'avais cette modif en local.